### PR TITLE
Added Service bus message additional fields

### DIFF
--- a/OpenCqrs.Bus.ServiceBus.Tests/Factories/MessageFactoryTests.cs
+++ b/OpenCqrs.Bus.ServiceBus.Tests/Factories/MessageFactoryTests.cs
@@ -20,8 +20,8 @@ namespace OpenCqrs.Bus.ServiceBus.Tests.Factories
         [Test]
         public void CreateMessage_SerializesCorrectly()
         {
-            var _someMessage = new SomeBusMessage();
-            var message = _sut.CreateMessage(_someMessage);
+            var someMessage = new SomeBusMessage();
+            var message = _sut.CreateMessage(someMessage);
             Assert.NotNull(message);
             Assert.NotNull(message.Body);
             Assert.Greater(message.Body.Length, 0);
@@ -29,13 +29,13 @@ namespace OpenCqrs.Bus.ServiceBus.Tests.Factories
         }
 
         [Test]
-        public void CreateMessage_DeerializesCorrectType()
+        public void CreateMessage_DeserializesCorrectType()
         {
-            var _someMessage = new SomeBusMessage();
-            var busMessage = _sut.CreateMessage(_someMessage);
+            var someMessage = new SomeBusMessage();
+            var busMessage = _sut.CreateMessage(someMessage);
             var messageType = System.Type.GetType(busMessage.UserProperties[MessageFactory.AssemblyQualifiedNamePropertyName] as string);
             var deserializedMessage = JsonConvert.DeserializeObject(System.Text.Encoding.UTF8.GetString(busMessage.Body), messageType);
-            Assert.AreEqual(_someMessage.GetType(), deserializedMessage.GetType());
+            Assert.AreEqual(someMessage.GetType(), deserializedMessage.GetType());
         }
     }
 }

--- a/OpenCqrs.Bus.ServiceBus.Tests/Factories/MessageFactoryTests.cs
+++ b/OpenCqrs.Bus.ServiceBus.Tests/Factories/MessageFactoryTests.cs
@@ -1,0 +1,41 @@
+using Moq;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using OpenCqrs.Bus;
+using OpenCqrs.Bus.ServiceBus.Factories;
+using OpenCqrs.Bus.ServiceBus.Tests.Fakes;
+
+namespace OpenCqrs.Bus.ServiceBus.Tests.Factories
+{
+    public class MessageFactoryTests
+    {
+        private MessageFactory _sut;
+
+        [SetUp]
+        public void Setup()
+        {
+            _sut = new MessageFactory();
+        }
+
+        [Test]
+        public void CreateMessage_SerializesCorrectly()
+        {
+            var _someMessage = new SomeBusMessage();
+            var message = _sut.CreateMessage(_someMessage);
+            Assert.NotNull(message);
+            Assert.NotNull(message.Body);
+            Assert.Greater(message.Body.Length, 0);
+            Assert.True(message.UserProperties.ContainsKey(MessageFactory.AssemblyQualifiedNamePropertyName));
+        }
+
+        [Test]
+        public void CreateMessage_DeerializesCorrectType()
+        {
+            var _someMessage = new SomeBusMessage();
+            var busMessage = _sut.CreateMessage(_someMessage);
+            var messageType = System.Type.GetType(busMessage.UserProperties[MessageFactory.AssemblyQualifiedNamePropertyName] as string);
+            var deserializedMessage = JsonConvert.DeserializeObject(System.Text.Encoding.UTF8.GetString(busMessage.Body), messageType);
+            Assert.AreEqual(_someMessage.GetType(), deserializedMessage.GetType());
+        }
+    }
+}

--- a/OpenCqrs.Bus.ServiceBus.Tests/Fakes/SomeBusMessage.cs
+++ b/OpenCqrs.Bus.ServiceBus.Tests/Fakes/SomeBusMessage.cs
@@ -7,9 +7,6 @@ namespace OpenCqrs.Bus.ServiceBus.Tests.Fakes
     internal class SomeBusMessage : IBusMessage
     {
         public DateTime? ScheduledEnqueueTimeUtc { get; set; }
-        public string SessionId { get; set; }
-        public string CorrelationId { get; set; }
-        public IDictionary<string, object> UserProperties { get; set; }
-        public string Label { get; set; }
+        public IDictionary<string, object> Properties { get; set; }
     }
 }

--- a/OpenCqrs.Bus.ServiceBus.Tests/Fakes/SomeBusMessage.cs
+++ b/OpenCqrs.Bus.ServiceBus.Tests/Fakes/SomeBusMessage.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OpenCqrs.Bus.ServiceBus.Tests.Fakes
+{
+    internal class SomeBusMessage : IBusMessage
+    {
+        public DateTime? ScheduledEnqueueTimeUtc { get; set; }
+        public string SessionId { get; set; }
+        public string CorrelationId { get; set; }
+        public IDictionary<string, object> UserProperties { get; set; }
+        public string Label { get; set; }
+    }
+}

--- a/OpenCqrs.Bus.ServiceBus.Tests/OpenCqrs.Bus.ServiceBus.Tests.csproj
+++ b/OpenCqrs.Bus.ServiceBus.Tests/OpenCqrs.Bus.ServiceBus.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="nunit" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\OpenCqrs.Bus.ServiceBus\OpenCqrs.Bus.ServiceBus.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/OpenCqrs.sln
+++ b/OpenCqrs.sln
@@ -59,7 +59,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenCqrs.Bus.ServiceBus", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenCqrs.Store.EF.InMemory", "src\OpenCqrs.Store.EF.InMemory\OpenCqrs.Store.EF.InMemory.csproj", "{15940312-6446-4FD6-B886-49BAC6589D73}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenCqrs.Bus.RabbitMQ", "src\OpenCqrs.Bus.RabbitMQ\OpenCqrs.Bus.RabbitMQ.csproj", "{BFF4E920-0653-41ED-AB20-4DB9EECD63A0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenCqrs.Bus.RabbitMQ", "src\OpenCqrs.Bus.RabbitMQ\OpenCqrs.Bus.RabbitMQ.csproj", "{BFF4E920-0653-41ED-AB20-4DB9EECD63A0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenCqrs.Bus.ServiceBus.Tests", "OpenCqrs.Bus.ServiceBus.Tests\OpenCqrs.Bus.ServiceBus.Tests.csproj", "{781016AA-A751-440D-8F02-A73AA128281A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -139,6 +141,10 @@ Global
 		{BFF4E920-0653-41ED-AB20-4DB9EECD63A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BFF4E920-0653-41ED-AB20-4DB9EECD63A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BFF4E920-0653-41ED-AB20-4DB9EECD63A0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{781016AA-A751-440D-8F02-A73AA128281A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{781016AA-A751-440D-8F02-A73AA128281A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{781016AA-A751-440D-8F02-A73AA128281A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{781016AA-A751-440D-8F02-A73AA128281A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -162,6 +168,7 @@ Global
 		{C3467348-3A8B-4558-B954-6A124E187FC3} = {A9692D21-8091-4A3F-8F7C-54B821EFDF97}
 		{15940312-6446-4FD6-B886-49BAC6589D73} = {A9692D21-8091-4A3F-8F7C-54B821EFDF97}
 		{BFF4E920-0653-41ED-AB20-4DB9EECD63A0} = {A9692D21-8091-4A3F-8F7C-54B821EFDF97}
+		{781016AA-A751-440D-8F02-A73AA128281A} = {54E87113-D720-41C2-A0DE-C4D61FB15AE5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {154500C3-9A83-4F15-9D78-E1C285AD80AE}

--- a/examples/OpenCqrs.Examples.Domain/Events/ProductCreatedBusMessage.cs
+++ b/examples/OpenCqrs.Examples.Domain/Events/ProductCreatedBusMessage.cs
@@ -12,9 +12,6 @@ namespace OpenCqrs.Examples.Domain.Events
 
         public DateTime? ScheduledEnqueueTimeUtc { get; set; }
         public string TopicName { get; set; } = "product-created";
-        public string SessionId { get; set; }
-        public string CorrelationId { get; set; }
-        public IDictionary<string, object> UserProperties { get; set; }
-        public string Label { get; set; }
+        public IDictionary<string, object> Properties { get; set; }
     }
 }

--- a/examples/OpenCqrs.Examples.Domain/Events/ProductCreatedBusMessage.cs
+++ b/examples/OpenCqrs.Examples.Domain/Events/ProductCreatedBusMessage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using OpenCqrs.Bus;
 using OpenCqrs.Domain;
 
@@ -11,5 +12,9 @@ namespace OpenCqrs.Examples.Domain.Events
 
         public DateTime? ScheduledEnqueueTimeUtc { get; set; }
         public string TopicName { get; set; } = "product-created";
+        public string SessionId { get; set; }
+        public string CorrelationId { get; set; }
+        public IDictionary<string, object> UserProperties { get; set; }
+        public string Label { get; set; }
     }
 }

--- a/src/OpenCqrs.Bus.ServiceBus/Factories/MessageFactory.cs
+++ b/src/OpenCqrs.Bus.ServiceBus/Factories/MessageFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Collections.Generic;
+using System.Text;
 using Microsoft.Azure.ServiceBus;
 using Newtonsoft.Json;
 
@@ -6,14 +7,26 @@ namespace OpenCqrs.Bus.ServiceBus.Factories
 {
     public class MessageFactory : IMessageFactory
     {
+        public static readonly string AssemblyQualifiedNamePropertyName = "AssemblyQualifiedName";
         /// <inheritdoc />
         public Message CreateMessage<TMessage>(TMessage message) where TMessage : IBusMessage
         {
             var json = JsonConvert.SerializeObject(message);
-            var serviceBusMessage = new Message(Encoding.UTF8.GetBytes(json));
+            var serviceBusMessage = new Message(Encoding.UTF8.GetBytes(json))
+            {
+                ContentType = "application/json"
+            };
 
             if (message.ScheduledEnqueueTimeUtc.HasValue)
                 serviceBusMessage.ScheduledEnqueueTimeUtc = message.ScheduledEnqueueTimeUtc.Value;
+            if (string.IsNullOrWhiteSpace(message.Label))
+                serviceBusMessage.Label = message.Label;
+            if (!string.IsNullOrWhiteSpace(message.SessionId))
+                serviceBusMessage.SessionId = message.SessionId;
+            if (!string.IsNullOrWhiteSpace(message.CorrelationId))
+                serviceBusMessage.CorrelationId = message.CorrelationId;
+
+            serviceBusMessage.UserProperties.Add(new KeyValuePair<string, object>(AssemblyQualifiedNamePropertyName, message.GetType().AssemblyQualifiedName));
 
             return serviceBusMessage;
         }

--- a/src/OpenCqrs.Bus.ServiceBus/Factories/MessageFactory.cs
+++ b/src/OpenCqrs.Bus.ServiceBus/Factories/MessageFactory.cs
@@ -19,12 +19,26 @@ namespace OpenCqrs.Bus.ServiceBus.Factories
 
             if (message.ScheduledEnqueueTimeUtc.HasValue)
                 serviceBusMessage.ScheduledEnqueueTimeUtc = message.ScheduledEnqueueTimeUtc.Value;
-            if (string.IsNullOrWhiteSpace(message.Label))
-                serviceBusMessage.Label = message.Label;
-            if (!string.IsNullOrWhiteSpace(message.SessionId))
-                serviceBusMessage.SessionId = message.SessionId;
-            if (!string.IsNullOrWhiteSpace(message.CorrelationId))
-                serviceBusMessage.CorrelationId = message.CorrelationId;
+
+            if (message.Properties != null)
+            {
+                foreach (var prop in message.Properties)
+                {
+                    // We could use reflexion here, but i believe we should bet on performace and simplicity.
+                    // If not, then we can consider adding more of this properties
+                    // Last note, we should do the same for rabbit.
+                    if (prop.Key == "Label")
+                        serviceBusMessage.Label = message.Properties[prop.Key] as string;
+                    else if (prop.Key == "SessionId")
+                        serviceBusMessage.SessionId = message.Properties[prop.Key] as string;
+                    else if (prop.Key == "CorrelationId")
+                        serviceBusMessage.CorrelationId = message.Properties[prop.Key] as string;
+                    else if (prop.Key == "ScheduledEnqueueTimeUtc" && message.Properties[prop.Key] is System.DateTime ScheduledEnqueueTimeUtc)
+                        serviceBusMessage.ScheduledEnqueueTimeUtc = ScheduledEnqueueTimeUtc;
+                    else
+                        serviceBusMessage.UserProperties.Add(prop.Key, prop.Value);
+                }
+            }
 
             serviceBusMessage.UserProperties.Add(new KeyValuePair<string, object>(AssemblyQualifiedNamePropertyName, message.GetType().AssemblyQualifiedName));
 

--- a/src/OpenCqrs.Bus.ServiceBus/Factories/MessageFactory.cs
+++ b/src/OpenCqrs.Bus.ServiceBus/Factories/MessageFactory.cs
@@ -24,13 +24,13 @@ namespace OpenCqrs.Bus.ServiceBus.Factories
                     // We could use reflexion here, but i believe we should bet on performace and simplicity.
                     // If not, then we can consider adding more of this properties
                     // Last note, we should do the same for rabbit.
-                    if (prop.Key == "Label")
+                    if (prop.Key == nameof(serviceBusMessage.Label))
                         serviceBusMessage.Label = message.Properties[prop.Key] as string;
-                    else if (prop.Key == "SessionId")
+                    else if (prop.Key == nameof(serviceBusMessage.SessionId))
                         serviceBusMessage.SessionId = message.Properties[prop.Key] as string;
-                    else if (prop.Key == "CorrelationId")
+                    else if (prop.Key == nameof(serviceBusMessage.CorrelationId))
                         serviceBusMessage.CorrelationId = message.Properties[prop.Key] as string;
-                    else if (prop.Key == "ScheduledEnqueueTimeUtc" && message.Properties[prop.Key] is System.DateTime ScheduledEnqueueTimeUtc)
+                    else if (prop.Key == nameof(serviceBusMessage.ScheduledEnqueueTimeUtc) && message.Properties[prop.Key] is System.DateTime ScheduledEnqueueTimeUtc)
                         serviceBusMessage.ScheduledEnqueueTimeUtc = ScheduledEnqueueTimeUtc;
                     else
                         serviceBusMessage.UserProperties.Add(prop.Key, prop.Value);

--- a/src/OpenCqrs.Bus.ServiceBus/Factories/MessageFactory.cs
+++ b/src/OpenCqrs.Bus.ServiceBus/Factories/MessageFactory.cs
@@ -37,7 +37,10 @@ namespace OpenCqrs.Bus.ServiceBus.Factories
                 }
             }
 
-            if (message.ScheduledEnqueueTimeUtc.HasValue && !message.Properties.ContainsKey(nameof(message.ScheduledEnqueueTimeUtc)))
+            //NOTE: we keep prop mapping this for legacy users, it's been marked as obsolete and should be removed in a future release
+            if (message.ScheduledEnqueueTimeUtc.HasValue
+                && message.Properties != null
+                && !message.Properties.ContainsKey(nameof(message.ScheduledEnqueueTimeUtc)) )
                 serviceBusMessage.ScheduledEnqueueTimeUtc = message.ScheduledEnqueueTimeUtc.Value;
 
             serviceBusMessage.UserProperties.Add(new KeyValuePair<string, object>(AssemblyQualifiedNamePropertyName, message.GetType().AssemblyQualifiedName));

--- a/src/OpenCqrs.Bus.ServiceBus/Factories/MessageFactory.cs
+++ b/src/OpenCqrs.Bus.ServiceBus/Factories/MessageFactory.cs
@@ -17,9 +17,6 @@ namespace OpenCqrs.Bus.ServiceBus.Factories
                 ContentType = "application/json"
             };
 
-            if (message.ScheduledEnqueueTimeUtc.HasValue)
-                serviceBusMessage.ScheduledEnqueueTimeUtc = message.ScheduledEnqueueTimeUtc.Value;
-
             if (message.Properties != null)
             {
                 foreach (var prop in message.Properties)
@@ -39,6 +36,9 @@ namespace OpenCqrs.Bus.ServiceBus.Factories
                         serviceBusMessage.UserProperties.Add(prop.Key, prop.Value);
                 }
             }
+
+            if (message.ScheduledEnqueueTimeUtc.HasValue && !message.Properties.ContainsKey(nameof(message.ScheduledEnqueueTimeUtc)))
+                serviceBusMessage.ScheduledEnqueueTimeUtc = message.ScheduledEnqueueTimeUtc.Value;
 
             serviceBusMessage.UserProperties.Add(new KeyValuePair<string, object>(AssemblyQualifiedNamePropertyName, message.GetType().AssemblyQualifiedName));
 

--- a/src/OpenCqrs/Bus/IBusMessage.cs
+++ b/src/OpenCqrs/Bus/IBusMessage.cs
@@ -5,10 +5,8 @@ namespace OpenCqrs.Bus
 {
     public interface IBusMessage
     {
+        [Obsolete("Set add a new entry in Properties with the key ScheduledEnqueueTimeUtc instead")]
         DateTime? ScheduledEnqueueTimeUtc { get; set; }
-        string SessionId { get; set; }
-        string CorrelationId { get; set; }
-        IDictionary<string, object> UserProperties { get; set; }
-        string Label { get; set; }
+        IDictionary<string, object> Properties { get; set; }
     }
 }

--- a/src/OpenCqrs/Bus/IBusMessage.cs
+++ b/src/OpenCqrs/Bus/IBusMessage.cs
@@ -1,9 +1,14 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace OpenCqrs.Bus
 {
     public interface IBusMessage
     {
         DateTime? ScheduledEnqueueTimeUtc { get; set; }
+        string SessionId { get; set; }
+        string CorrelationId { get; set; }
+        IDictionary<string, object> UserProperties { get; set; }
+        string Label { get; set; }
     }
 }

--- a/test/OpenCqrs.Tests/Fakes/AggregateCreated.cs
+++ b/test/OpenCqrs.Tests/Fakes/AggregateCreated.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using OpenCqrs.Bus;
 using OpenCqrs.Domain;
 
@@ -8,5 +9,9 @@ namespace OpenCqrs.Tests.Fakes
     {
         public DateTime? ScheduledEnqueueTimeUtc { get; set; }
         public string QueueName { get; set; } = "queue-name";
+        public string SessionId { get; set; }
+        public string CorrelationId { get; set; }
+        public IDictionary<string, object> UserProperties { get; set; }
+        public string Label { get; set; }
     }
 }

--- a/test/OpenCqrs.Tests/Fakes/AggregateCreated.cs
+++ b/test/OpenCqrs.Tests/Fakes/AggregateCreated.cs
@@ -9,9 +9,6 @@ namespace OpenCqrs.Tests.Fakes
     {
         public DateTime? ScheduledEnqueueTimeUtc { get; set; }
         public string QueueName { get; set; } = "queue-name";
-        public string SessionId { get; set; }
-        public string CorrelationId { get; set; }
-        public IDictionary<string, object> UserProperties { get; set; }
-        public string Label { get; set; }
+        public IDictionary<string, object> Properties { get; set; }
     }
 }

--- a/test/OpenCqrs.Tests/Fakes/CreateAggregateBusMessage.cs
+++ b/test/OpenCqrs.Tests/Fakes/CreateAggregateBusMessage.cs
@@ -9,9 +9,6 @@ namespace OpenCqrs.Tests.Fakes
     {
         public DateTime? ScheduledEnqueueTimeUtc { get; set; }
         public string QueueName { get; set; } = "create-something";
-        public string SessionId { get; set; }
-        public string CorrelationId { get; set; }
-        public IDictionary<string, object> UserProperties { get; set; }
-        public string Label { get; set; }
+        public IDictionary<string, object> Properties { get; set; }
     }
 }

--- a/test/OpenCqrs.Tests/Fakes/CreateAggregateBusMessage.cs
+++ b/test/OpenCqrs.Tests/Fakes/CreateAggregateBusMessage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using OpenCqrs.Bus;
 using OpenCqrs.Domain;
 
@@ -8,5 +9,9 @@ namespace OpenCqrs.Tests.Fakes
     {
         public DateTime? ScheduledEnqueueTimeUtc { get; set; }
         public string QueueName { get; set; } = "create-something";
+        public string SessionId { get; set; }
+        public string CorrelationId { get; set; }
+        public IDictionary<string, object> UserProperties { get; set; }
+        public string Label { get; set; }
     }
 }

--- a/test/OpenCqrs.Tests/Fakes/SomethingCreated.cs
+++ b/test/OpenCqrs.Tests/Fakes/SomethingCreated.cs
@@ -9,9 +9,6 @@ namespace OpenCqrs.Tests.Fakes
     {
         public DateTime? ScheduledEnqueueTimeUtc { get; set; }
         public string QueueName { get; set; } = "queue-name";
-        public string SessionId {get; set; }
-        public string CorrelationId {get; set; }
-        public IDictionary<string, object> UserProperties {get; set; }
-        public string Label {get; set; }
+        public IDictionary<string, object> Properties { get; set; }
     }
 }

--- a/test/OpenCqrs.Tests/Fakes/SomethingCreated.cs
+++ b/test/OpenCqrs.Tests/Fakes/SomethingCreated.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using OpenCqrs.Bus;
 using OpenCqrs.Events;
 
@@ -8,5 +9,9 @@ namespace OpenCqrs.Tests.Fakes
     {
         public DateTime? ScheduledEnqueueTimeUtc { get; set; }
         public string QueueName { get; set; } = "queue-name";
+        public string SessionId {get; set; }
+        public string CorrelationId {get; set; }
+        public IDictionary<string, object> UserProperties {get; set; }
+        public string Label {get; set; }
     }
 }


### PR DESCRIPTION
Hello, 
I had a requirement while doing a project and thought on few things that led to this change.
I understand if it's not on the project's scope and it gets rejected. I just had the idea of how to implement it so I just wrote it down:

1. I've added some properties that might be helpful when reading the messages. I have used service bus specific naming, which we can rename to accommodate rabitmq, for example the Label property functions as Subject. I have added CorrelationId and SessionId which will be very helpful for developers.
2. Added some basic unit tests, I don't know if it covers enough or if it follows the styling.

My reasoning behind this is that we can use more properties of Message class the same way ScheduledEnqueueTimeUtc exists.

What do you guys think?

I can always create and inject my own Message Factory, but I think this can lead to a better project.

I have more plans for this in the upcoming weeks.

Cheers